### PR TITLE
PRODENG-2119 example/aws outputs for hosts and dns

### DIFF
--- a/examples/aws/main.tf
+++ b/examples/aws/main.tf
@@ -123,6 +123,7 @@ locals {
       privateInterface = "Ethernet 2"
     }
   ]
+
   mke_launchpad_tmpl = {
     apiVersion = "launchpad.mirantis.com/mke/v1.3"
     kind       = "mke"
@@ -172,3 +173,20 @@ locals {
 output "mke_cluster" {
   value = yamlencode(local.launchpad_tmpl)
 }
+
+
+output "hosts" {
+  value = concat(local.managers, local.msrs, local.workers, local.windows_workers)
+  description = "All hosts in the cluster"
+}
+
+output "mke_lb" {
+  value = module.masters.lb_dns_name
+  description = "LB path for the MKE ingress"
+}
+
+output "msr_lb" {
+  value = module.msrs.lb_dns_name
+  description = "LB path for the MSR ingress"
+}
+


### PR DESCRIPTION
- new outputs added to allow for parametrized consumption of created resouces as outputs to couple to other modules.